### PR TITLE
Optimize default sql performance

### DIFF
--- a/lib/delayed/backend/active_record.rb
+++ b/lib/delayed/backend/active_record.rb
@@ -112,6 +112,9 @@ module Delayed
           # This is our old fashion, tried and true, but possibly slower lookup
           # Instead of reading the entire job record for our detect loop, just pluck the ID,
           # and only read the job record after we've successfully locked the job.
+          # This can be particularly helpful when operating a large job cluster that uses
+          # a large read_ahead value to increase the odds of successfully locking a job with
+          # one method call to reserve_with_scope.
           locked_job_id = ready_scope.limit(worker.read_ahead).pluck(:id).detect do |job_id|
             count = ready_scope.where(id: job_id).update_all(locked_at: now, locked_by: worker.name)
             count == 1


### PR DESCRIPTION
This PR modifies the `:default_sql` strategy to optimize the logic used to acquire a lock on a job.

Instead of reading `worker.read_ahead` number of job **records** from the server in the detect loop of `reserve_with_scope_using_default_sql`, we instead just pluck the job **ids**, and only read the job record after we've successfully locked the job.

This can be particularly helpful when operating a large job cluster that uses a larger `read_ahead` value. This increases the odds of successfully locking a job in just one call to `reserve`, since the more job workers you have working a given queue, the more likely it is that the jobs you just fetched are already locked by another worker.

By fetching just the IDs, we speed up the query time (IDs can be read directly from the index vs the table data), network time (transmitting significantly less data over the wire), and ruby time (less object instantiations, no active record model instantiations). These improvements reduce the amount of time any one worker spends between fetching a list of potential jobs to work and actually locking a job. This means there is less chance of another worker grabbing those jobs before a lock can be acquired.
